### PR TITLE
changes autoProccessQueue to autoProcessQueue

### DIFF
--- a/addon/components/drop-zone/component.js
+++ b/addon/components/drop-zone/component.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
   maxFiles: null,
   // resize
   acceptedFiles: null,
-  autoProccessQueue: null,
+  autoProcessQueue: null,
   forceFallback: null,
 
   // Dropzone translations
@@ -92,7 +92,7 @@ export default Ember.Component.extend({
       "thumbnailHeight",
       "maxFiles",
       "acceptedFiles",
-      "autoProccessQueue",
+      "autoProcessQueue",
       "forceFallback",
       "dictDefaultMessage",
       "dictFallbackMessage",
@@ -149,7 +149,7 @@ export default Ember.Component.extend({
       this.maxFiles,
       // resize
       this.acceptedFiles,
-      this.autoProccessQueue,
+      this.autoProcessQueue,
       this.forceFallback,
 
       // Dropzone translations


### PR DESCRIPTION
this option has double c's in the component, but requires a single c for proper configuration with dropzone (see http://www.dropzonejs.com/#config-autoProcessQueue)
