### PR TITLE
default blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ Installation
 -------------
 `ember install ember-cli-dropzonejs`
 
-then
-
-`bower install dropzone`
-
 This addon will use dropzone's default css by default. If you prefer to use your own css, add this option to your `Brocfile.js`:
 
 ```javascript

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-cli-dropzonejs/index.js
+++ b/blueprints/ember-cli-dropzonejs/index.js
@@ -1,0 +1,8 @@
+/*jshint node:true*/
+module.exports = {
+  normalizeEntityName: function() {},
+
+  afterInstall: function(options) {
+    return this.addBowerPackageToProject('dropzone');
+  }
+};

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-dropzonejs",
   "dependencies": {
-    "dropzone": "^4.0.1",
+    "dropzone": "^4.3.0",
     "ember": "1.13.7",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",

--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ module.exports = {
 
     var options = app.options.emberCliDropzonejs || {includeDropzoneCss: true};
 
-    app.import('bower_components/dropzone/dist/dropzone.js');
+    app.import(app.bowerDirectory + '/dropzone/dist/dropzone.js');
 
     if (options.includeDropzoneCss){
-      app.import('bower_components/dropzone/dist/dropzone.css');
+      app.import(app.bowerDirectory + '/dropzone/dist/dropzone.css');
     }
 
   }


### PR DESCRIPTION
Adds a default addon blueprint to install the dropzone bower dep. Now during installation, the blueprint will be ran and will install dropzonejs for inclusion. 

Additionally `ember install ember-cli-dropzonejs` can be used to run the default blueprint.
