### PR TITLE
Fix flickering when dragging over child element

### DIFF
--- a/addon/components/drop-zone.js
+++ b/addon/components/drop-zone.js
@@ -128,6 +128,30 @@ export default Ember.Component.extend({
   },
 
   getDropzoneOptions() {
+    const onDragEnterLeaveHandler = function(dropzoneInstance) {
+      const onDrag = ( element => {
+        let dragCounter = 0;
+        
+        return {
+          enter(event) {
+            event.preventDefault();
+            dragCounter++;
+            element.classList.add('dz-drag-hover');
+          },
+          leave(event) {
+            dragCounter--;
+            
+            if (dragCounter === 0) {
+              element.classList.remove('dz-drag-hover');
+            }
+          }
+        }
+      })(dropzoneInstance.element);
+      
+      dropzoneInstance.on('dragenter', onDrag.enter);
+      dropzoneInstance.on('dragleave', onDrag.leave);
+    };
+    
     let dropzoneOptions = {};
     let dropzoneConfig = {
       url: this.url,
@@ -164,6 +188,11 @@ export default Ember.Component.extend({
       dictCancelUploadConfirmation: this.dictCancelUploadConfirmation,
       dictRemoveFile: this.dictRemoveFile,
       dictMaxFilesExceeded: this.dictMaxFilesExceeded,
+      
+      // Fix flickering dragging over child elements: https://github.com/enyo/dropzone/issues/438
+      dragenter: Ember.$.noop,
+      dragleave: Ember.$.noop,
+      init: function () { onDragEnterLeaveHandler(this) }
     };
 
     for (let option in dropzoneConfig) {

--- a/addon/components/drop-zone.js
+++ b/addon/components/drop-zone.js
@@ -138,14 +138,14 @@ export default Ember.Component.extend({
             dragCounter++;
             element.classList.add('dz-drag-hover');
           },
-          leave(event) {
+          leave() {
             dragCounter--;
             
             if (dragCounter === 0) {
               element.classList.remove('dz-drag-hover');
             }
           }
-        }
+        };
       })(dropzoneInstance.element);
       
       dropzoneInstance.on('dragenter', onDrag.enter);
@@ -192,7 +192,7 @@ export default Ember.Component.extend({
       // Fix flickering dragging over child elements: https://github.com/enyo/dropzone/issues/438
       dragenter: Ember.$.noop,
       dragleave: Ember.$.noop,
-      init: function () { onDragEnterLeaveHandler(this) }
+      init: function () { onDragEnterLeaveHandler(this); }
     };
 
     for (let option in dropzoneConfig) {


### PR DESCRIPTION
If dragged over the child element, the `dz-drag-hover` class is removed. See https://github.com/enyo/dropzone/issues/438 for more info.

It's unlikely this problem will be fixed in the core of [dropzonejs](https://github.com/enyo/dropzone/) soon, so applied the fix made by @jhubert. Code can be deleted as soon dropzonjs team fixes this.
