### PR TITLE
Update included hook for nested addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,18 +4,19 @@
 module.exports = {
   name: 'ember-cli-dropzonejs',
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
-    var options = app.options.emberCliDropzonejs || {includeDropzoneCss: true};
+    var host = this._findHost();
+
+    var options = host.options && host.options.emberCliDropzonejs || { includeDropzoneCss: true };
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
       // This will only be included in the browser build
-      app.import(app.bowerDirectory + '/dropzone/dist/dropzone.js');
+      this.import(host.bowerDirectory + '/dropzone/dist/dropzone.js');
     }
 
     if (options.includeDropzoneCss){
-      app.import(app.bowerDirectory + '/dropzone/dist/dropzone.css');
+      this.import(host.bowerDirectory + '/dropzone/dist/dropzone.css');
     }
-
   }
 };

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "1.1.0"
+    "ember-cli-htmlbars": "1.1.0",
+    "ember-cli-import-polyfill": "0.2.0"
   },
   "browser": {
     "jquery": "../jquery/jquery.js",


### PR DESCRIPTION
I update the to add the feature to be nested into another addon. I add `ember-cli-import-polyfill` to have access to the new `this.import` syntax and the polyfill add a nice function  `_findHost` to retrieve informations of the top parent app.
