### PR TITLE
Make it work with Glimmer 2

### DIFF
--- a/addon/components/drop-zone.js
+++ b/addon/components/drop-zone.js
@@ -5,9 +5,7 @@ export default Ember.Component.extend({
   classNames: ['dropzone'],
 
   myDropzone:undefined,
-
-  element: null,
-
+  
   dropzoneOptions: null,
 
   // Configuration Options


### PR DESCRIPTION
This line was added in https://github.com/FutoRicky/ember-cli-dropzonejs/commit/1479bfda7d29c0069fba5c1775a10b044e4f58c5 and doesn't seem needed, all components have an element property already.

Fixes https://github.com/FutoRicky/ember-cli-dropzonejs/issues/51
