### PR TITLE
adds new optional param maxDropRegion

### DIFF
--- a/addon/components/drop-zone.js
+++ b/addon/components/drop-zone.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   classNames: ['dropzone'],
 
-  myDropzone:undefined,
+  myDropzone: document.body || undefined,
   
   dropzoneOptions: null,
 
@@ -45,6 +45,9 @@ export default Ember.Component.extend({
   dictCancelUploadConfirmation: null,
   dictRemoveFile: null,
   dictMaxFilesExceeded: null,
+
+  // Bonus for full screen zones
+  maxDropRegion: null,
 
   // Events
 
@@ -208,7 +211,8 @@ export default Ember.Component.extend({
   },
 
   createDropzone(element) {
-    this.set('myDropzone', new Dropzone(element, this.dropzoneOptions));
+    let region = this.get('maxDropRegion') ? document.body : element;
+    this.set('myDropzone', new Dropzone(region, this.dropzoneOptions));
   },
 
   insertDropzone: Ember.on('didInsertElement', function() {


### PR DESCRIPTION
This allows the entire document body to be a dropzone. Might be wise to force `clickable` to be false if `maxDropRegion === true` enabled, but for now I'm leaving that as is. Use it like this:

```hbs
{{drop-zone url='https://example.com' maxDropRegion=true clickable='.js-upload-button'}}

```